### PR TITLE
Access webapp over wifi

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,6 +31,7 @@
 * [Web APP](web-app/README.md)
   * [Installation](web-app/installation.md)
   * [Accessibility](web-app/accessibility.md)
+  * [Internationalization](web-app/internationalization.md)
 * [Environments](environments/README.md)
   * [Docker: Test / Production](environments/docker-test-production/README.md)
     * [Docker Configuration](environments/docker-test-production/docker-configuration.md)

--- a/web-app/installation.md
+++ b/web-app/installation.md
@@ -1,12 +1,9 @@
-# Installation
+# Docker Installation
 
-## Setup the Web App via Docker
 
-## Setup the Web App locally
+_More information will follow shortly_
 
-### Installation
-
-#### Build Setup
+# Local Installation
 
 Run:
 
@@ -45,14 +42,6 @@ $ yarn run styleguide
 ```
 
 When built you can open it at [http://localhost:6060](http://localhost:6060)
-
-## Localization
-
-> Located in two places!
-
-`locales/`
-
-[Lokalise.co](https://lokalise.co/public/829625945b3c04bf56d560.80490143/)
 
 #### Backpack
 

--- a/web-app/installation.md
+++ b/web-app/installation.md
@@ -12,11 +12,11 @@ Run:
 $ yarn install
 
 # serve with hot reload at localhost:3000
-$ yarn dev
+$ yarn run dev
 
 # build once and launch server
-$ yarn build
-$ yarn start
+$ yarn run build
+$ yarn run start
 ```
 
 For detailed explanation on how things work, checkout the [Nuxt.js docs](https://github.com/nuxt/nuxt.js).
@@ -32,6 +32,23 @@ For detailed explanation on how things work, checkout the [Nuxt.js docs](https:/
 | Admin | test@test.de | 1234 |
 | Moderator | test2@test2.de | 1234 |
 | User | test3@test3.de | 1234 |
+
+#### Access over WiFi
+
+In order to make your web app accessible from your local WiFi you have to
+configure `WEBAPP_HOST`, `WEBAPP_BASE_URL` and `API_HOST` depending on your
+IP address within that network. E.g. on Linux you can check your IP address with
+`ip addr`. Here's an example `.env` file for an IP address `192.168.178.42`:
+
+```sh
+# .env 
+WEBAPP_HOST     = 192.168.178.42
+WEBAPP_BASE_URL = http://192.168.178.42:3000
+API_HOST        = 192.168.178.42
+```
+
+You can use this configuration e.g. to test the webapp from your mobile phone.
+
 
 #### Styleguide
 

--- a/web-app/internationalization.md
+++ b/web-app/internationalization.md
@@ -1,0 +1,10 @@
+## Internationalization
+
+We translate the application for two languages at the moment, English and German.
+You can find all translations for the frontend in two files:
+
+`locales/en.json`
+`locales/de.json`
+
+Feel free to contribute to our translations and join our project at
+[Lokalise.co](https://lokalise.co/public/829625945b3c04bf56d560.80490143/)!


### PR DESCRIPTION
This is already the documentation after the branch `fix-docker-setup` has been merged into master. Right now, the `.env` gets overwritten every time you do `yarn run dev`. At the moment, the workflow is:

````sh
export LOCAL_IP=192.168.178.42
env WEBAPP_HOST=$LOCAL_IP WEBAPP_BASE_URL=http://$LOCAL_IP:3000 API_HOST=$LOCAL_IP yarn run dev
```