### PR TITLE
Correcting an Error in "Setup the API via Docker"

### DIFF
--- a/server-api/installation.md
+++ b/server-api/installation.md
@@ -4,11 +4,15 @@
 
 ### Installation
 
-Make sure you have a recent version of [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system.  
+Make sure you have a recent version of [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system.
 
+After that, you clone the repo by typing
 
-To determine the installed version, run:  
+ ```bash
+   $ git clone https://github.com/Human-Connection/API.git
+   ```
 
+and determine the installed version, running  
 
 ```bash
 $ docker-compose up --build


### PR DESCRIPTION
Added the following 2 lines:
- After that, you clone the repo by typing
-  $ git clone https://github.com/Human-Connection/API.git

Changed the line
 - To determine the installed version, run:
into
- and determine the installed version, running

This changes - I hope - let peaple turn into a more "alife" workflow, following the instructions in a "flowing" sentence...
Does anyone understand me? ;-)
Or is this - in germen - Kauderwelschig? :-D

Best wishes to you all
Andreas